### PR TITLE
Fixed errors after breaking changes in redux-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-redux": "^4.4.5",
+    "react-redux": "^4.4.5 || ^5.0.0",
     "redux": "^3.6.0",
     "redux-form": "^6.1.1",
     "redux-thunk": "^2.1.0"

--- a/src/field.js
+++ b/src/field.js
@@ -16,7 +16,9 @@ const createInlineError = (name, inlineErrorClass, meta) => {
     return null;
 };
 
-export function FieldRenderer({ input, meta, type, name, label, className, errorClass, inlineErrorClass, ...props }) {
+export function FieldRenderer({ input, meta, type, label, className, errorClass, inlineErrorClass, ...props }) {
+    const name = input.name;
+
     const inlineError = createInlineError(name, inlineErrorClass, meta);
     const ekstraProps = {
         'aria-invalid': meta.touched && !!meta.error,
@@ -38,7 +40,6 @@ FieldRenderer.propTypes = {
     input: PT.object.isRequired, // eslint-disable-line react/forbid-prop-types
     meta: PT.object.isRequired, // eslint-disable-line react/forbid-prop-types
     type: PT.string.isRequired,
-    name: PT.string.isRequired,
     label: PT.node.isRequired,
     className: PT.string,
     errorClass: PT.string,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -2,6 +2,9 @@ import { reducer as formReducer } from 'redux-form';
 
 export function updatedFormState(form, oldState, newState) {
     const formState = { ...oldState[form], ...newState };
+
+    console.log('nState', form, newState);
+
     return {
         ...oldState,
         [form]: formState
@@ -25,19 +28,16 @@ export default function reducer(state = {}, action) {
     }
 
     // Actual reducer logic
-    switch (action.type) {
-        case 'redux-form/SET_SUBMIT_FAILED': {
-            return updatedFormState(form, nState, { submittoken: 'token' });
+    if (action.type.indexOf('redux-form/SET_SUBMIT_FAILED') >= 0) {
+        return updatedFormState(form, nState, { submittoken: 'token' });
+    } else if (action.type.indexOf('redux-form/UPDATE_SYNC_ERRORS') >= 0) {
+        const errors = action.payload.syncErrors || {};
+
+        if (Object.keys(errors).length === 0) {
+            return updatedFormState(form, nState, { submittoken: null });
         }
-        case 'redux-form/UPDATE_SYNC_ERRORS': {
-            const errors = action.payload.syncErrors || {};
-            if (Object.keys(errors).length === 0) {
-                return updatedFormState(form, nState, { submittoken: null });
-            }
-            return nState;
-        }
-        default: {
-            return nState;
-        }
+        return nState;
+    } else {
+        return nState;
     }
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -3,8 +3,6 @@ import { reducer as formReducer } from 'redux-form';
 export function updatedFormState(form, oldState, newState) {
     const formState = { ...oldState[form], ...newState };
 
-    console.log('nState', form, newState);
-
     return {
         ...oldState,
         [form]: formState


### PR DESCRIPTION
Redux-form added `@@` infront of all actions, switched to using `indexOf` insteadof exact match.
Allowing react-redux 5.x.x
