### PR TITLE
Allow react-node as feedback header

### DIFF
--- a/src/feedback-summary.js
+++ b/src/feedback-summary.js
@@ -79,7 +79,7 @@ export function feedbackSummaryFactory(listCreator = DefaultListCreator,
         header: 'Errors'
     };
     FeedbackSummary.propTypes = {
-        header: PT.string.isRequired
+        header: PT.node.isRequired
     };
 
     return FeedbackSummary;


### PR DESCRIPTION
This change will make it easier to use the component together with react-intl as you can create a form with:
```
const myForm = validForm({
    formName: 'myForm',
    errorSummaryTitle: <FormattedMessage id="myform.errorsummary.title" />
});
```