### PR TITLE
Pass props to validation-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In your form use the `react-form-validation` components.
     Title Label
 </LabelledField>
 ```
-When making your `redux-form` use `react-form-validation`'s `validForm` method, and pass it a `validate` prop for the fields that you want to validate. `react-form-validation` also provides rules that you can use to simplefy the declaration.
+When making your `redux-form` use `react-form-validation`'s `validForm` method, and pass it a `validate` prop for the fields that you want to validate. `react-form-validation` also provides rules that you can use to simplify the declaration.
 ```
 const myValidForm = validForm({
     form: 'my-form',

--- a/src/validate.js
+++ b/src/validate.js
@@ -21,12 +21,12 @@ export const rules = {
 };
 
 export default function validate(config) {
-    return (values) =>
+    return (values, props) =>
         Object.entries(config)
             .map(([field, allrules]) => ({
                 field,
                 errors: arrayOf(allrules)
-                    .map((rule) => rule(values[field]))
+                    .map((rule) => rule(values[field], props))
                     .filter((rule) => rule)
             }))
             .filter(({ errors }) => errors && errors.length > 0)


### PR DESCRIPTION
The signature of RefuxForm.validate() is (values:Object, props:Object ) => errors:Object. This allows validators to read the props of the form, something that should be possible in react-form-validation as well