### PR TITLE
use react v16.0-compatible proptype-imports

### DIFF
--- a/example/login.js
+++ b/example/login.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
-import React, { PropTypes as PT } from 'react';
+import React from 'react';
+import PT from 'prop-types';
 import { SubmissionError } from 'redux-form';
 import LabelledField from '../src/fields/labelled-field';
 import CustomField from '../src/fields/custom-field';

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "peerDependencies": {
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
+    "prop-types": "^15.5.10",
     "react-redux": "^4.4.5 || ^5.0.0",
     "redux": "^3.6.0",
     "redux-form": "^6.1.1",

--- a/src/feedback-summary.js
+++ b/src/feedback-summary.js
@@ -1,4 +1,5 @@
-import React, { PropTypes as PT, Component } from 'react';
+import React, { Component } from 'react';
+import PT from 'prop-types';
 
 export function DefaultListCreator({ header, errors }) {
     return (

--- a/src/fields/custom-field.js
+++ b/src/fields/custom-field.js
@@ -1,4 +1,5 @@
-import React, { PropTypes as PT, cloneElement } from 'react';
+import React, { cloneElement } from 'react';
+import PT from 'prop-types';
 import { Field } from 'redux-form';
 import { fieldClasses } from './field-utils';
 

--- a/src/fields/labelled-field.js
+++ b/src/fields/labelled-field.js
@@ -1,4 +1,5 @@
-import React, { PropTypes as PT } from 'react';
+import React from 'react';
+import PT from 'prop-types';
 import { Field } from 'redux-form';
 import { createInlineError, fieldClasses } from './field-utils';
 

--- a/src/validForm.js
+++ b/src/validForm.js
@@ -1,4 +1,5 @@
-import React, { createElement, PropTypes as PT, Component } from 'react';
+import React, { createElement, Component } from 'react';
+import PT from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import { Fields, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';


### PR DESCRIPTION
Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs